### PR TITLE
Update GNOME runtime to 42

### DIFF
--- a/io.otsaloma.nfoview.yml
+++ b/io.otsaloma.nfoview.yml
@@ -1,6 +1,6 @@
 app-id: io.otsaloma.nfoview
 runtime: org.gnome.Platform
-runtime-version: "40"
+runtime-version: "42"
 sdk: org.gnome.Sdk
 command: nfoview
 finish-args:


### PR DESCRIPTION
Minor note - GTK3 apps don't look stellar on the GNOME 42 runtime IMO (at least on my system, the get their app icon placed next to them)

Other GTK3 apps are updating the runtime to version 42 though, so that's probably still worth updating to anyways