### PR TITLE
Update to 1.99 and

### DIFF
--- a/io.otsaloma.nfoview.yml
+++ b/io.otsaloma.nfoview.yml
@@ -4,6 +4,9 @@ runtime-version: "44"
 sdk: org.gnome.Sdk
 command: nfoview
 finish-args:
+  - --filesystem=home
+  - --filesystem=xdg-music
+  - --filesystem=xdg-videos
   - --share=ipc
   - --socket=wayland
   - --socket=x11
@@ -16,5 +19,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/otsaloma/nfoview.git
-        tag: "1.29"
-        commit: a4ea1c1bcc20a0c0918b1269c67ef83aac619391
+        tag: "1.99"
+        commit: e182556be30d38b645f8e7e63c32eb9840db47d9


### PR DESCRIPTION
* ~Update GNOME runtime to 44~ (done already earlier)
* Add missing filesystem permissions (how did this work before?)